### PR TITLE
Cache modulo operator in New

### DIFF
--- a/pwgen.go
+++ b/pwgen.go
@@ -10,9 +10,11 @@ const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_-?
 // New() generates a random string of the given length
 func New(length int) string {
 	var bytes = make([]byte, length)
+	var op = byte(len(chars))
+
 	rand.Read(bytes)
 	for i, b := range bytes {
-		bytes[i] = chars[b%byte(len(chars))]
+		bytes[i] = chars[b%op]
 	}
 	return string(bytes)
 }


### PR DESCRIPTION
Instead of recreating the operator in each iterator, we can cache it before the loop.
